### PR TITLE
feat: add PyPi PyO3 bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release-CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+          - runner: ubuntu-latest
+            target: aarch64
+          - runner: ubuntu-latest
+            target: armv7
+          - runner: ubuntu-latest
+            target: s390x
+          - runner: ubuntu-latest
+            target: ppc64le
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Update version
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run:
+          # Set version from github tags to the value of carg version
+          sed -i '0,/version/s/version = ".*"/version = "${{ github.ref_name }}"/' Cargo.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: dist
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+          - runner: windows-latest
+            target: x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
+      - name: Update version
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run:
+          # Set version from github tags to the value of carg version
+          sed -i '0,/version/s/version = ".*"/version = "${{ github.ref_name }}"/' Cargo.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: dist
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-12
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Update version
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run:
+          # Set version from github tags to the value of carg version
+          sed -i '' '0,/version/s/version = ".*"/version = "${{ github.ref_name }}"/' Cargo.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update version
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run:
+          # Set version from github tags to the value of carg version
+          sed -i '0,/version/s/version = ".*"/version = "${{ github.ref_name }}"/' Cargo.toml
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, windows, macos, sdist]
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "csv_generator"
 version = "1.0.0"
 edition = "2021"
 
+[lib]
+name = "datahobbit"
+crate-type = ["cdylib"]
+
 [dependencies]
 clap = { version = "4.3", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["maturin>=1.6,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "datahobbit"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]
+dependencies = ["typer"]
+
+[project.optional-dependencies]
+dev = ["ruff"]
+
+[project.scripts]
+datahobbit = "datahobbit.app:entry_point"
+
+[tool.ruff]
+line-length = 120
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "datahobbit.native"
+

--- a/python/datahobbit/app.py
+++ b/python/datahobbit/app.py
@@ -1,0 +1,57 @@
+from enum import Enum
+
+import typer
+from typing_extensions import Annotated
+
+from .native import py_entry_point
+
+NATIVE_USIZE_MAX_VALUE = 18_446_744_073_709_551_615
+
+
+help_str = """
+[bold][green]Data Generator[/green][/bold]\n
+[italic]Generates CSV or Parquet files from a JSON schema[/italic]
+
+Author: Daniel Beach <dancrystalbeach@gmail.com>
+Source code: https://github.com/danielbeach/datahobbit
+"""
+
+app = typer.Typer(
+    rich_markup_mode="rich",
+    help=help_str,
+)
+
+
+class FormatType(str, Enum):
+    CSV = "csv"
+    PARQUET = "parquet"
+
+
+def main(
+    input: Annotated[str, typer.Option(help="Sets the input JSON schema file")],
+    output: Annotated[str, typer.Option(help="Sets the output file prefix")],
+    records: Annotated[
+        int, typer.Option(min=0, max=NATIVE_USIZE_MAX_VALUE, help="Sets the number of records to generate")
+    ],
+    delimeter: Annotated[str, typer.Option(help="Sets the delimiter to use in the CSV file (default is ',')")] = ",",
+    format: Annotated[
+        FormatType, typer.Option("--format", help='Output format: either "csv" or "parquet"')
+    ] = FormatType.CSV,
+    max_file_size: Annotated[
+        int,
+        typer.Option(min=0, max=NATIVE_USIZE_MAX_VALUE, help="Sets the maximum file size for Parquet files (in bytes)"),
+    ] = 100 * 1024 * 1024,
+):
+    if len(delimeter) != 1:
+        raise ValueError(f"Delimeter expected to be a one symbol, but got '{delimeter}'")
+    else:
+        delimeter_char = ord(delimeter)
+    py_entry_point(input, output, records, delimeter_char, format.value, max_file_size)
+
+
+def entry_point():
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    entry_point()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,24 @@
 use anyhow::{anyhow, Result};
-use fake::Fake;
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
 use fake::faker::boolean::en::Boolean;
 use fake::faker::internet::en::{Password, SafeEmail};
 use fake::faker::lorem::en::{Sentence, Word};
 use fake::faker::name::en::{FirstName, LastName, Name};
 use fake::faker::phone_number::en::PhoneNumber;
+use fake::Fake;
 use indicatif::{ProgressBar, ProgressStyle};
-use rand::Rng;
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
-use rayon::prelude::ParallelBridge;
-use serde::Deserialize;
-use std::fs::File;
-use std::io::{BufWriter, Write};
-use std::sync::{Arc, Mutex};
-use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
-use arrow::record_batch::RecordBatch;
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::file::properties::WriterProperties;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rand::Rng;
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use serde::Deserialize;
 use std::fs::metadata;
-
+use std::fs::File;
+use std::io::BufWriter;
+use std::sync::{Arc, Mutex};
 
 #[derive(Deserialize)]
 struct Schema {
@@ -34,9 +34,13 @@ struct Column {
 
 fn get_generator(data_type: &str) -> Result<Box<dyn Fn() -> String + Send + Sync>> {
     match data_type {
-        "integer" => Ok(Box::new(|| rand::thread_rng().gen_range(0..1000).to_string())),
+        "integer" => Ok(Box::new(|| {
+            rand::thread_rng().gen_range(0..1000).to_string()
+        })),
         "string" => Ok(Box::new(|| Word().fake::<String>())),
-        "float" => Ok(Box::new(|| rand::thread_rng().gen_range(0.0..1000.0).to_string())),
+        "float" => Ok(Box::new(|| {
+            rand::thread_rng().gen_range(0.0..1000.0).to_string()
+        })),
         "boolean" => Ok(Box::new(|| Boolean(50).fake::<bool>().to_string())),
         "name" => Ok(Box::new(|| Name().fake::<String>())),
         "first_name" => Ok(Box::new(|| FirstName().fake::<String>())),
@@ -52,24 +56,52 @@ fn get_generator(data_type: &str) -> Result<Box<dyn Fn() -> String + Send + Sync
 const MAX_ROW_GROUPS_PER_FILE: usize = 32767;
 const DEFAULT_BATCH_SIZE: usize = 5000; // Adjusted batch size
 
-pub fn generate_parquet(input_file: &str, output_prefix: &str, records: usize, max_file_size: usize) -> Result<()> {
+pub fn generate_parquet(
+    input_file: &str,
+    output_prefix: &str,
+    records: usize,
+    max_file_size: usize,
+) -> Result<()> {
     let file = File::open(input_file)?;
     let reader = std::io::BufReader::new(file);
     let schema: Schema = serde_json::from_reader(reader)?;
 
-    let arrow_fields = schema.columns.iter()
+    let arrow_fields = schema
+        .columns
+        .iter()
         .map(|col| match col.data_type.as_str() {
-            "integer" => Ok(arrow::datatypes::Field::new(&col.name, arrow::datatypes::DataType::Int64, false)),
-            "float" => Ok(arrow::datatypes::Field::new(&col.name, arrow::datatypes::DataType::Float64, false)),
-            "boolean" => Ok(arrow::datatypes::Field::new(&col.name, arrow::datatypes::DataType::Boolean, false)),
-            "string" | "name" | "first_name" | "last_name" | "email" | "password" | "sentence" | "phone_number" => 
-                Ok(arrow::datatypes::Field::new(&col.name, arrow::datatypes::DataType::Utf8, false)),
-            _ => Err(anyhow!("Unsupported data type for Parquet: {}", col.data_type)),
+            "integer" => Ok(arrow::datatypes::Field::new(
+                &col.name,
+                arrow::datatypes::DataType::Int64,
+                false,
+            )),
+            "float" => Ok(arrow::datatypes::Field::new(
+                &col.name,
+                arrow::datatypes::DataType::Float64,
+                false,
+            )),
+            "boolean" => Ok(arrow::datatypes::Field::new(
+                &col.name,
+                arrow::datatypes::DataType::Boolean,
+                false,
+            )),
+            "string" | "name" | "first_name" | "last_name" | "email" | "password" | "sentence"
+            | "phone_number" => Ok(arrow::datatypes::Field::new(
+                &col.name,
+                arrow::datatypes::DataType::Utf8,
+                false,
+            )),
+            _ => Err(anyhow!(
+                "Unsupported data type for Parquet: {}",
+                col.data_type
+            )),
         })
         .collect::<Result<Vec<_>>>()?;
 
     let arrow_schema = Arc::new(arrow::datatypes::Schema::new(arrow_fields));
-    let generators: Vec<_> = schema.columns.iter()
+    let generators: Vec<_> = schema
+        .columns
+        .iter()
         .map(|column| get_generator(&column.data_type))
         .collect::<Result<_>>()?;
 
@@ -81,7 +113,8 @@ pub fn generate_parquet(input_file: &str, output_prefix: &str, records: usize, m
         let file = File::create(&output_file)?;
         let buf_writer = BufWriter::new(file);
         let writer_props = WriterProperties::builder().build();
-        let mut writer = ArrowWriter::try_new(buf_writer, arrow_schema.clone(), Some(writer_props))?;
+        let mut writer =
+            ArrowWriter::try_new(buf_writer, arrow_schema.clone(), Some(writer_props))?;
 
         let mut current_file_size = 0;
         let mut row_group_count = 0;
@@ -95,15 +128,29 @@ pub fn generate_parquet(input_file: &str, output_prefix: &str, records: usize, m
                 rows.push(row);
             }
 
-            let columns: Vec<ArrayRef> = (0..schema.columns.len()).map(|i| {
-                let values: Vec<String> = rows.iter().map(|row| row[i].clone()).collect();
-                match schema.columns[i].data_type.as_str() {
-                    "integer" => Arc::new(Int64Array::from(values.iter().map(|v| v.parse::<i64>().unwrap()).collect::<Vec<_>>())) as ArrayRef,
-                    "float" => Arc::new(Float64Array::from(values.iter().map(|v| v.parse::<f64>().unwrap()).collect::<Vec<_>>())) as ArrayRef,
-                    "boolean" => Arc::new(BooleanArray::from(values.iter().map(|v| v == "true").collect::<Vec<_>>())) as ArrayRef,
-                    _ => Arc::new(StringArray::from(values)) as ArrayRef,
-                }
-            }).collect();
+            let columns: Vec<ArrayRef> = (0..schema.columns.len())
+                .map(|i| {
+                    let values: Vec<String> = rows.iter().map(|row| row[i].clone()).collect();
+                    match schema.columns[i].data_type.as_str() {
+                        "integer" => Arc::new(Int64Array::from(
+                            values
+                                .iter()
+                                .map(|v| v.parse::<i64>().unwrap())
+                                .collect::<Vec<_>>(),
+                        )) as ArrayRef,
+                        "float" => Arc::new(Float64Array::from(
+                            values
+                                .iter()
+                                .map(|v| v.parse::<f64>().unwrap())
+                                .collect::<Vec<_>>(),
+                        )) as ArrayRef,
+                        "boolean" => Arc::new(BooleanArray::from(
+                            values.iter().map(|v| v == "true").collect::<Vec<_>>(),
+                        )) as ArrayRef,
+                        _ => Arc::new(StringArray::from(values)) as ArrayRef,
+                    }
+                })
+                .collect();
 
             let batch = RecordBatch::try_new(arrow_schema.clone(), columns)?;
             writer.write(&batch)?;
@@ -125,7 +172,6 @@ pub fn generate_parquet(input_file: &str, output_prefix: &str, records: usize, m
 
     Ok(())
 }
-
 
 pub fn generate_csv(
     input_file: &str,
@@ -165,7 +211,9 @@ pub fn generate_csv(
 
     // Handle the Result from .template()
     let progress_style = ProgressStyle::default_bar()
-        .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {percent}% ({pos}/{len})")
+        .template(
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {percent}% ({pos}/{len})",
+        )
         .expect("Failed to set progress bar template")
         .progress_chars("#>-");
     progress_bar.set_style(progress_style);
@@ -199,5 +247,33 @@ pub fn generate_csv(
 
     let mut wtr = wtr.lock().unwrap();
     wtr.flush()?;
+    Ok(())
+}
+
+#[pyfunction]
+fn py_entry_point(
+    input: &str,
+    output: &str,
+    records: usize,
+    delimiter: u8,
+    data_format: &str,
+    max_file_size: usize,
+) -> PyResult<()> {
+    let result = match data_format {
+        "csv" => generate_csv(&input, &output, records, delimiter),
+        "parquet" => generate_parquet(&input, &output, records, max_file_size),
+        _ => unreachable!(),
+    };
+
+    match result {
+        Err(e) => Err(PyErr::new::<PyValueError, _>(format!("Error: {}", e))),
+        Ok(_) => Ok(()),
+    }
+}
+
+#[pymodule]
+fn native(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_entry_point, m)?)?;
+
     Ok(())
 }


### PR DESCRIPTION
This PR introduced a pip-installable version of the `datahobbit`.

What was changed:
- Added a `pyproject.toml` that follows PEP621 and uses `maturin` as a build sytem;
- Slightly modified the `Cargo.toml` by adding a library section (`maturin` cannot work with binary);
- To `lib.rs` added an entry point for the PyO3 binginds;
- Added a GH action for PyPi publishing;


P.S. I accidently applied `rust-analyzer` `format` to all the `lib.rs`, but I can revert it if needed.


close #2 
cc: @MrPowers


How to try it?
- Install maturin: https://www.maturin.rs/installation
- Run `maturin build --release`
- The resulted python wheel can be installed via pip: `pip install target/datahobbit...whl`
- `datahobbit --help`

```sh
                                                                                                                                                            
 Usage: datahobbit [OPTIONS]
                                                                                                                                                            
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --input                TEXT                                        Sets the input JSON schema file [default: None] [required]                         │
│ *  --output               TEXT                                        Sets the output file prefix [default: None] [required]                             │
│ *  --records              INTEGER RANGE [0<=x<=18446744073709551615]  Sets the number of records to generate [default: None] [required]                  │
│    --delimeter            TEXT                                        Sets the delimiter to use in the CSV file (default is ',') [default: ,]            │
│    --format               [csv|parquet]                               Output format: either "csv" or "parquet" [default: csv]                            │
│    --max-file-size        INTEGER RANGE [0<=x<=18446744073709551615]  Sets the maximum file size for Parquet files (in bytes) [default: 104857600]       │
│    --help                                                             Show this message and exit.                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```