### PR TITLE
Change chrono version to 0.4.39 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ indicatif = "0.17.8"
 pyo3 = { version = "0.22.5", features = ["extension-module"] }
 parquet = "53.2.0"
 arrow = "53.2.0"
-chrono = "=0.4.38"
+chrono = "=0.4.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ indicatif = "0.17.8"
 pyo3 = { version = "0.22.5", features = ["extension-module"] }
 parquet = "53.2.0"
 arrow = "53.2.0"
+chrono = "=0.4.38"


### PR DESCRIPTION
The change is required as currently cargo build fails due to the error showcased in [this reddit comment](https://www.reddit.com/r/rust/comments/1iz0py1/comment/mezt60s/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) (or at least that is the case when building for the first time).

![image](https://github.com/user-attachments/assets/697070fb-a619-4a07-ad83-a98b1b25d679)


Explanation:
![image](https://github.com/user-attachments/assets/7317dda6-71b1-4275-9474-7876272cc14f)
